### PR TITLE
Km GitHub following

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@ class UsersController < ApplicationController
   def show
     @list = current_user.repos unless current_user.token.nil?
     @followers = current_user.followers unless current_user.token.nil?
+    @following = current_user.following unless current_user.token.nil?
   end
 
   def new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,4 +33,17 @@ class User < ApplicationRecord
     end
     list
   end
+
+  def following
+    conn = Faraday.new(url: 'https://api.github.com') do |faraday|
+      faraday.headers['Authorization'] = "token #{token}"
+    end
+    repo = conn.get('/user/following')
+    json = JSON.parse(repo.body, symbolize_names: true)
+    list = []
+    json.each do |follower|
+      list << follower[:login]
+    end
+    list
+  end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -29,6 +29,14 @@
       <% end %>
     </section>
 
+    <section id='github-following'>
+      <h3> Following </h3>
+      <% @following.each do |follow| %>
+        <%= link_to "#{follow}", "https://github.com/#{follow}" %>
+        <p></p>
+      <% end %>
+    </section>
+
   <% else %>
     <%= link_to "Connect to Github", "https://github.com/login/oauth/authorize?client_id=e5b765e6ce409b1727a6&scope=repo" %>
   <% end %>

--- a/spec/features/user/user_can_see_github_info_spec.rb
+++ b/spec/features/user/user_can_see_github_info_spec.rb
@@ -33,6 +33,13 @@ describe 'User' do
       expect(page).to have_content("alex-latham")
       expect(page).to have_content("DavidTTran")
     end
+    
+    within("#github-following") do
+      expect(page).to have_content("Following")
+      expect(page).to have_link("treyx")
+      expect(page).to have_link("tylertomlinson")
+      expect(page).to have_link("DavidTTran")
+    end
 
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -51,5 +51,15 @@ RSpec.describe User, type: :model do
 
       expect(user.followers).to eq(["alex-latham", "DavidTTran"])
     end
+    
+    it 'following' do
+      user = User.create(email: 'user@email.com',
+        password: 'password',
+        first_name:'Jim',
+        role: 0,
+        token: "#{ENV['GITHUB_TOKEN']}")
+
+      expect(user.following).to eq(["treyx", "tylertomlinson", "DavidTTran"])
+    end
   end
 end


### PR DESCRIPTION
Adds functionality and testing to existing cade to enable display of a User's Github people they are following.

All tests passing locally.